### PR TITLE
Added ip method to grab the containers mapped port's ip

### DIFF
--- a/app/ip.go
+++ b/app/ip.go
@@ -91,7 +91,14 @@ func ipPublicAction(c *cli.Context) error {
 		logrus.Fatalf("Failed to find IP: %v", err)
 	}
 
-	fmt.Printf("%q", strings.Split(selfContainer.Ports[0], ":")[0])
+	if len(selfContainer.Ports) > 0 {
+		// split 53.129.140.240:3002:80/tcp by : to access ip
+		parts := strings.Split(selfContainer.Ports[0], ":")
+
+		if len(parts) > 0 {
+			fmt.Print(parts[0])
+		}
+	}
 
 	return nil
 }

--- a/app/ip.go
+++ b/app/ip.go
@@ -62,6 +62,10 @@ func IPCommand() cli.Command {
 				Name:   "myip",
 				Usage:  "Prints the containers Rancher managed IP",
 				Action: ipMyIpAction,
+			}, {
+				Name:   "public",
+				Usage:  "Prints the containers port mapped managed IP",
+				Action: ipPublicAction,
 			},
 		},
 	}
@@ -75,6 +79,19 @@ func ipMyIpAction(c *cli.Context) error {
 		logrus.Fatalf("Failed to find IP: %v", err)
 	}
 	fmt.Print(selfContainer.PrimaryIp)
+
+	return nil
+}
+
+func ipPublicAction(c *cli.Context) error {
+	mdClient, _ := metadata.NewClientAndWait(metadataURL)
+
+	selfContainer, err := mdClient.GetSelfContainer()
+	if err != nil {
+		logrus.Fatalf("Failed to find IP: %v", err)
+	}
+
+	fmt.Printf("%q", strings.Split(selfContainer.Ports[0], ":")[0])
 
 	return nil
 }


### PR DESCRIPTION
Added a new function to grab the container's mapped port's ip. The normal myip function gathers the primary ip essentially like so:

```
curl -s http://rancher-metadata/latest/self/container/primary_ip
10.42.51.9
```

This gathers from the following url:

```
curl -s http://rancher-metadata/latest/self/container/ports/0
52.119.140.240:3002:80/tcp
```

Then splits on `:` allowing it to return the ip of the mapped port: `52.119.140.240`

Example:

```
/opt/rancher/bin # ./giddyup ip public
52.119.140.240
```
