### PR TITLE
Assume leader only if truely the lowest create index

### DIFF
--- a/election/proxy.go
+++ b/election/proxy.go
@@ -66,7 +66,7 @@ func (w *Watcher) getLeader() (metadata.Container, bool, error) {
 	}
 
 	w.leader = leader
-	return leader, leader.PrimaryIp == selfContainer.PrimaryIp, nil
+	return leader, leader.Uuid == selfContainer.Uuid, nil
 }
 
 func (w *Watcher) Forwarder() error {


### PR DESCRIPTION
The current `giddyup leader check` logic is not quite what we want (for etcd). It first searches for the lowest create_index container and then, if the encapsulating container's IP address matches that container, assumes it is the leader.

This is problematic if we use `giddyup leader check` in conjunction with `retain_ip` to perform first-run bootstrap logic. During upgrade, the stopped container that was (and still is) truly the leader will match an upgraded container's IP address and the bootstrap logic is triggered a second time. Instead, we should only compare the create index to prevent the re-bootstrapping.

Note: The reason we don't see this bug all the time during an etcd upgrade is because the check for an existing usable data directory occurs before the leader check. Up until now, the upgraded container was placed on an existing data directory. If this was not the case, we would've seen the erroneous behavior from the beginning.